### PR TITLE
feat: add --convert-nan-to-null to emit spec-compliant JSON

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -37,6 +37,11 @@ def main():
         action="store_true",
         help="Force overwriting output file if it already exists without prompting",
     )
+    parser.add_argument(
+        "--convert-nan-to-null",
+        action="store_true",
+        help="Convert NaN/Inf/-Inf floats to null when converting from SAV to JSON. This will lose information in the event Inf/-Inf is in the sav file (default: false)",
+    )
     parser.add_argument("--minify-json", action="store_true", help="Minify JSON output")
     args = parser.parse_args()
 
@@ -56,17 +61,30 @@ def main():
             output_path = args.filename + ".json"
         else:
             output_path = args.output
-        convert_sav_to_json(args.filename, output_path, args.force, args.minify_json)
+        convert_sav_to_json(
+            args.filename,
+            output_path,
+            force=args.force,
+            minify=args.minify_json,
+            allow_nan=(not args.convert_nan_to_null),
+        )
 
     if args.from_json or args.filename.endswith(".json"):
         if not args.output:
             output_path = args.filename.replace(".json", "")
         else:
             output_path = args.output
-        convert_json_to_sav(args.filename, output_path, args.force)
+        convert_json_to_sav(
+            args.filename,
+            output_path,
+            force=args.force,
+            allow_nan=(not args.convert_nan_to_null),
+        )
 
 
-def convert_sav_to_json(filename, output_path, force=False, minify=False):
+def convert_sav_to_json(
+    filename, output_path, force=False, minify=False, allow_nan=True
+):
     print(f"Converting {filename} to JSON, saving to {output_path}")
     if os.path.exists(output_path):
         print(f"{output_path} already exists, this will overwrite the file")
@@ -78,11 +96,15 @@ def convert_sav_to_json(filename, output_path, force=False, minify=False):
         data = f.read()
         raw_gvas, _ = decompress_sav_to_gvas(data)
     print(f"Loading GVAS file")
-    gvas_file = GvasFile.read(raw_gvas, PALWORLD_TYPE_HINTS, PALWORLD_CUSTOM_PROPERTIES)
+    gvas_file = GvasFile.read(
+        raw_gvas, PALWORLD_TYPE_HINTS, PALWORLD_CUSTOM_PROPERTIES, allow_nan=allow_nan
+    )
     print(f"Writing JSON to {output_path}")
     with open(output_path, "w", encoding="utf8") as f:
         indent = None if minify else "\t"
-        json.dump(gvas_file.dump(), f, indent=indent, cls=CustomEncoder)
+        json.dump(
+            gvas_file.dump(), f, indent=indent, cls=CustomEncoder, allow_nan=allow_nan
+        )
 
 
 def convert_json_to_sav(filename, output_path, force=False):

--- a/convert.py
+++ b/convert.py
@@ -74,12 +74,7 @@ def main():
             output_path = args.filename.replace(".json", "")
         else:
             output_path = args.output
-        convert_json_to_sav(
-            args.filename,
-            output_path,
-            force=args.force,
-            allow_nan=(not args.convert_nan_to_null),
-        )
+        convert_json_to_sav(args.filename, output_path, force=args.force)
 
 
 def convert_sav_to_json(

--- a/lib/archive.py
+++ b/lib/archive.py
@@ -124,6 +124,15 @@ class FArchiveReader:
     def __exit__(self, type, value, traceback):
         self.data.close()
 
+    def internal_copy(self, data, debug: bool) -> "FArchiveReader":
+        return FArchiveReader(
+            data,
+            self.type_hints,
+            self.custom_properties,
+            debug=debug,
+            allow_nan=self.allow_nan,
+        )
+
     def get_type_or(self, path: str, default: str):
         if path in self.type_hints:
             return self.type_hints[path]

--- a/lib/archive.py
+++ b/lib/archive.py
@@ -1,4 +1,5 @@
 import io
+import math
 import os
 import struct
 import uuid
@@ -107,12 +108,14 @@ class FArchiveReader:
         type_hints: dict[str, str] = {},
         custom_properties: dict[str, tuple[Callable, Callable]] = {},
         debug: bool = os.environ.get("DEBUG", "0") == "1",
+        allow_nan: bool = True,
     ):
         self.data = io.BytesIO(data)
         self.size = len(data)
         self.type_hints = type_hints
         self.custom_properties = custom_properties
         self.debug = debug
+        self.allow_nan = allow_nan
 
     def __enter__(self):
         self.data.seek(0)
@@ -204,13 +207,23 @@ class FArchiveReader:
 
     unpack_float = struct.Struct("f").unpack
 
-    def float(self) -> _float:
-        return FArchiveReader.unpack_float(self.data.read(4))[0]
+    def float(self) -> Optional[_float]:
+        val = FArchiveReader.unpack_float(self.data.read(4))[0]
+        if self.allow_nan:
+            return val
+        if val == math.nan or val == math.inf or val == -math.inf:
+            return None
+        return val
 
     unpack_double = struct.Struct("d").unpack
 
-    def double(self) -> _float:
-        return FArchiveReader.unpack_double(self.data.read(8))[0]
+    def double(self) -> Optional[_float]:
+        val = FArchiveReader.unpack_double(self.data.read(8))[0]
+        if self.allow_nan:
+            return val
+        if val == math.nan or val == math.inf or val == -math.inf:
+            return None
+        return val
 
     unpack_byte = struct.Struct("B").unpack
 
@@ -465,7 +478,9 @@ class FArchiveReader:
         value = int.from_bytes(b, "little")
         return value
 
-    def packed_vector(self, scale_factor: int) -> tuple[_float, _float, _float]:
+    def packed_vector(
+        self, scale_factor: int
+    ) -> tuple[Optional[_float], Optional[_float], Optional[_float]]:
         component_bit_count_and_extra_info = self.u32()
         component_bit_count = component_bit_count_and_extra_info & 63
         extra_info = component_bit_count_and_extra_info >> 6
@@ -488,20 +503,22 @@ class FArchiveReader:
             else:
                 return (self.float(), self.float(), self.float())
 
-    def vector(self) -> tuple[_float, _float, _float]:
+    def vector(self) -> tuple[Optional[_float], Optional[_float], Optional[_float]]:
         return (self.double(), self.double(), self.double())
 
-    def vector_dict(self) -> dict[str, _float]:
+    def vector_dict(self) -> dict[str, Optional[_float]]:
         return {
             "x": self.double(),
             "y": self.double(),
             "z": self.double(),
         }
 
-    def quat(self) -> tuple[_float, _float, _float, _float]:
+    def quat(
+        self,
+    ) -> tuple[Optional[_float], Optional[_float], Optional[_float], Optional[_float]]:
         return (self.double(), self.double(), self.double(), self.double())
 
-    def quat_dict(self) -> dict[str, _float]:
+    def quat_dict(self) -> dict[str, Optional[_float]]:
         return {
             "x": self.double(),
             "y": self.double(),
@@ -509,7 +526,7 @@ class FArchiveReader:
             "w": self.double(),
         }
 
-    def ftransform(self) -> dict[str, dict[str, _float]]:
+    def ftransform(self) -> dict[str, dict[str, Optional[_float]]]:
         return {
             "rotation": self.quat_dict(),
             "translation": self.vector_dict(),
@@ -625,10 +642,14 @@ class FArchiveWriter:
     def u64(self, i: int):
         self.data.write(struct.pack("Q", i))
 
-    def float(self, i: float):
+    def float(self, i: Optional[float]):
+        if i is None:
+            i = float("nan")
         self.data.write(struct.pack("f", i))
 
-    def double(self, i: _float):
+    def double(self, i: Optional[_float]):
+        if i is None:
+            i = float("nan")
         self.data.write(struct.pack("d", i))
 
     def byte(self, b: int):
@@ -902,29 +923,35 @@ class FArchiveWriter:
             self.double(y)
             self.double(z)
 
-    def vector(self, x: _float, y: _float, z: _float):
+    def vector(self, x: Optional[_float], y: Optional[_float], z: Optional[_float]):
         self.double(x)
         self.double(y)
         self.double(z)
 
-    def vector_dict(self, value: dict[str, _float]):
+    def vector_dict(self, value: dict[str, Optional[_float]]):
         self.double(value["x"])
         self.double(value["y"])
         self.double(value["z"])
 
-    def quat(self, x: _float, y: _float, z: _float, w: _float):
+    def quat(
+        self,
+        x: Optional[_float],
+        y: Optional[_float],
+        z: Optional[_float],
+        w: Optional[_float],
+    ):
         self.double(x)
         self.double(y)
         self.double(z)
         self.double(w)
 
-    def quat_dict(self, value: dict[str, _float]):
+    def quat_dict(self, value: dict[str, Optional[_float]]):
         self.double(value["x"])
         self.double(value["y"])
         self.double(value["z"])
         self.double(value["w"])
 
-    def ftransform(self, value: dict[str, dict[str, _float]]):
+    def ftransform(self, value: dict[str, dict[str, Optional[_float]]]):
         self.quat_dict(value["rotation"])
         self.vector_dict(value["translation"])
         self.vector_dict(value["scale3d"])

--- a/lib/gvas.py
+++ b/lib/gvas.py
@@ -118,9 +118,10 @@ class GvasFile:
         data: bytes,
         type_hints: dict[str, str] = {},
         custom_properties: dict[str, tuple[Callable, Callable]] = {},
+        allow_nan: bool = True,
     ) -> "GvasFile":
         gvas_file = GvasFile()
-        with FArchiveReader(data, type_hints, custom_properties) as reader:
+        with FArchiveReader(data, type_hints, custom_properties, allow_nan) as reader:
             gvas_file.header = GvasHeader.read(reader)
             gvas_file.properties = reader.properties_until_end()
             gvas_file.trailer = reader.read_to_end()

--- a/lib/gvas.py
+++ b/lib/gvas.py
@@ -121,7 +121,12 @@ class GvasFile:
         allow_nan: bool = True,
     ) -> "GvasFile":
         gvas_file = GvasFile()
-        with FArchiveReader(data, type_hints, custom_properties, allow_nan) as reader:
+        with FArchiveReader(
+            data,
+            type_hints=type_hints,
+            custom_properties=custom_properties,
+            allow_nan=allow_nan,
+        ) as reader:
             gvas_file.header = GvasHeader.read(reader)
             gvas_file.properties = reader.properties_until_end()
             gvas_file.trailer = reader.read_to_end()

--- a/lib/rawdata/base_camp.py
+++ b/lib/rawdata/base_camp.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data = {
         "id": reader.guid(),
         "name": reader.fstring(),

--- a/lib/rawdata/base_camp_module.py
+++ b/lib/rawdata/base_camp_module.py
@@ -66,8 +66,10 @@ def module_passive_effect_reader(reader: FArchiveReader) -> dict[str, Any]:
     return data
 
 
-def decode_bytes(b_bytes: Sequence[int], module_type: str) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int], module_type: str
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
     if module_type in NO_OP_TYPES:
         pass

--- a/lib/rawdata/build_process.py
+++ b/lib/rawdata/build_process.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data = {
         "state": reader.byte(),
         "id": reader.guid(),

--- a/lib/rawdata/character.py
+++ b/lib/rawdata/character.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     char_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(char_bytes)
+    value["value"] = decode_bytes(reader, char_bytes)
     return value
 
 
-def decode_bytes(char_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(char_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, char_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(char_bytes), debug=False)
     char_data = {
         "object": reader.properties_until_end(),
         "unknown_bytes": reader.byte_list(4),

--- a/lib/rawdata/character_container.py
+++ b/lib/rawdata/character_container.py
@@ -10,14 +10,16 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(c_bytes: Sequence[int]) -> Optional[dict[str, Any]]:
+def decode_bytes(
+    parent_reader: FArchiveReader, c_bytes: Sequence[int]
+) -> Optional[dict[str, Any]]:
     if len(c_bytes) == 0:
         return None
-    reader = FArchiveReader(bytes(c_bytes), debug=False)
+    reader = parent_reader.internal_copy(bytes(c_bytes), debug=False)
     data = {
         "player_uid": reader.guid(),
         "instance_id": reader.guid(),

--- a/lib/rawdata/connector.py
+++ b/lib/rawdata/connector.py
@@ -10,7 +10,7 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
@@ -26,10 +26,12 @@ def connect_info_item_writer(writer: FArchiveWriter, properties: dict[str, Any])
     writer.byte(properties["index"])
 
 
-def decode_bytes(c_bytes: Sequence[int]) -> Optional[dict[str, Any]]:
+def decode_bytes(
+    parent_reader: FArchiveReader, c_bytes: Sequence[int]
+) -> Optional[dict[str, Any]]:
     if len(c_bytes) == 0:
         return None
-    reader = FArchiveReader(bytes(c_bytes), debug=False)
+    reader = parent_reader.internal_copy(bytes(c_bytes), debug=False)
     data: dict[str, Any] = {
         "supported_level": reader.i32(),
         "connect": {

--- a/lib/rawdata/dynamic_item.py
+++ b/lib/rawdata/dynamic_item.py
@@ -10,15 +10,17 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(c_bytes: Sequence[int]) -> Optional[dict[str, Any]]:
+def decode_bytes(
+    parent_reader: FArchiveReader, c_bytes: Sequence[int]
+) -> Optional[dict[str, Any]]:
     if len(c_bytes) == 0:
         return None
     buf = bytes(c_bytes)
-    reader = FArchiveReader(buf, debug=False)
+    reader = parent_reader.internal_copy(buf, debug=False)
     data: dict[str, Any] = {}
     data["id"] = {
         "created_world_id": reader.guid(),

--- a/lib/rawdata/foliage_model.py
+++ b/lib/rawdata/foliage_model.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
     data["model_id"] = reader.fstring()
     data["foliage_preset_type"] = reader.byte()

--- a/lib/rawdata/foliage_model_instance.py
+++ b/lib/rawdata/foliage_model_instance.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
     data["model_instance_id"] = reader.guid()
     pitch, yaw, roll = reader.compressed_short_rotator()

--- a/lib/rawdata/group.py
+++ b/lib/rawdata/group.py
@@ -14,12 +14,16 @@ def decode(
     for group in group_map:
         group_type = group["value"]["GroupType"]["value"]["value"]
         group_bytes = group["value"]["RawData"]["value"]["values"]
-        group["value"]["RawData"]["value"] = decode_bytes(group_bytes, group_type)
+        group["value"]["RawData"]["value"] = decode_bytes(
+            reader, group_bytes, group_type
+        )
     return value
 
 
-def decode_bytes(group_bytes: Sequence[int], group_type: str) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(group_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, group_bytes: Sequence[int], group_type: str
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(group_bytes), debug=False)
     group_data = {
         "group_type": group_type,
         "group_id": reader.guid(),

--- a/lib/rawdata/item_container.py
+++ b/lib/rawdata/item_container.py
@@ -10,14 +10,16 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(c_bytes: Sequence[int]) -> Optional[dict[str, Any]]:
+def decode_bytes(
+    parent_reader: FArchiveReader, c_bytes: Sequence[int]
+) -> Optional[dict[str, Any]]:
     if len(c_bytes) == 0:
         return None
-    reader = FArchiveReader(bytes(c_bytes), debug=False)
+    reader = parent_reader.internal_copy(bytes(c_bytes), debug=False)
     data = {}
     data["permission"] = {
         "type_a": reader.tarray(lambda r: r.byte()),

--- a/lib/rawdata/item_container_slots.py
+++ b/lib/rawdata/item_container_slots.py
@@ -10,14 +10,16 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(c_bytes: Sequence[int]) -> Optional[dict[str, Any]]:
+def decode_bytes(
+    parent_reader: FArchiveReader, c_bytes: Sequence[int]
+) -> Optional[dict[str, Any]]:
     if len(c_bytes) == 0:
         return None
-    reader = FArchiveReader(bytes(c_bytes), debug=False)
+    reader = parent_reader.internal_copy(bytes(c_bytes), debug=False)
     data: dict[str, Any] = {}
     data["permission"] = {
         "type_a": reader.tarray(lambda r: r.byte()),

--- a/lib/rawdata/map_model.py
+++ b/lib/rawdata/map_model.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(m_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(m_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, m_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(m_bytes), debug=False)
     data: dict[str, Any] = {}
     data["instance_id"] = reader.guid()
     data["concrete_model_instance_id"] = reader.guid()

--- a/lib/rawdata/work.py
+++ b/lib/rawdata/work.py
@@ -32,17 +32,19 @@ def decode(
     for work_element in value["value"]["values"]:
         work_bytes = work_element["RawData"]["value"]["values"]
         work_type = work_element["WorkableType"]["value"]["value"]
-        work_element["RawData"]["value"] = decode_bytes(work_bytes, work_type)
+        work_element["RawData"]["value"] = decode_bytes(reader, work_bytes, work_type)
         for work_assign in work_element["WorkAssignMap"]["value"]:
             work_assign_bytes = work_assign["value"]["RawData"]["value"]["values"]
             work_assign["value"]["RawData"]["value"] = decode_work_assign_bytes(
-                work_assign_bytes
+                reader, work_assign_bytes
             )
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int], work_type: str) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int], work_type: str
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
     # Handle base serialization
     if work_type in WORK_BASE_TYPES:
@@ -127,8 +129,10 @@ def decode_bytes(b_bytes: Sequence[int], work_type: str) -> dict[str, Any]:
     return data
 
 
-def decode_work_assign_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_work_assign_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
 
     data["id"] = reader.guid()

--- a/lib/rawdata/work_collection.py
+++ b/lib/rawdata/work_collection.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
     data["id"] = reader.guid()
     data["work_ids"] = reader.tarray(uuid_reader)

--- a/lib/rawdata/worker_director.py
+++ b/lib/rawdata/worker_director.py
@@ -10,12 +10,14 @@ def decode(
         raise Exception(f"Expected ArrayProperty, got {type_name}")
     value = reader.property(type_name, size, path, nested_caller_path=path)
     data_bytes = value["value"]["values"]
-    value["value"] = decode_bytes(data_bytes)
+    value["value"] = decode_bytes(reader, data_bytes)
     return value
 
 
-def decode_bytes(b_bytes: Sequence[int]) -> dict[str, Any]:
-    reader = FArchiveReader(bytes(b_bytes), debug=False)
+def decode_bytes(
+    parent_reader: FArchiveReader, b_bytes: Sequence[int]
+) -> dict[str, Any]:
+    reader = parent_reader.internal_copy(bytes(b_bytes), debug=False)
     data: dict[str, Any] = {}
     data["id"] = reader.guid()
     data["spawn_transform"] = reader.ftransform()

--- a/tests/test_rawdata.py
+++ b/tests/test_rawdata.py
@@ -4,6 +4,7 @@ import unittest
 
 from parameterized import parameterized
 
+from lib.archive import FArchiveReader
 from lib.json_tools import CustomEncoder
 from lib.rawdata import character, foliage_model_instance, group
 
@@ -23,7 +24,7 @@ class TestRawData(unittest.TestCase):
     )
     def test_character(self, name, test_base64):
         test_data = base64.b64decode(test_base64)
-        properties = character.decode_bytes(test_data)
+        properties = character.decode_bytes(FArchiveReader(b""), test_data)
         json_str = json.dumps(
             properties, cls=CustomEncoder, ensure_ascii=False, indent=2
         )
@@ -46,7 +47,7 @@ class TestRawData(unittest.TestCase):
     )
     def test_group(self, group_type, test_base64):
         test_data = base64.b64decode(test_base64)
-        properties = group.decode_bytes(test_data, group_type)
+        properties = group.decode_bytes(FArchiveReader(b""), test_data, group_type)
         json_str = json.dumps(
             properties, cls=CustomEncoder, ensure_ascii=False, indent=2
         )
@@ -65,7 +66,7 @@ class TestRawData(unittest.TestCase):
     )
     def test_foliage_model_instance(self, test_base64):
         test_data = base64.b64decode(test_base64)
-        properties = foliage_model_instance.decode_bytes(test_data)
+        properties = foliage_model_instance.decode_bytes(FArchiveReader(b""), test_data)
         json_str = json.dumps(
             properties, cls=CustomEncoder, ensure_ascii=False, indent=2
         )


### PR DESCRIPTION
Fixes #108 by emit spec-compliant JSON at the cost of potential loss of information (Inf/-Inf are encoded back into NaNs), which should be very rare.

This is currently missing test cases.