### PR TITLE
Improve 17.2x performance for UUID == operate

### DIFF
--- a/palworld_save_tools/archive.py
+++ b/palworld_save_tools/archive.py
@@ -72,6 +72,8 @@ class UUID:
         return str(self.parsed_uuid)
 
     def __eq__(self, __value: object) -> bool:
+        if isinstance(__value, UUID):
+            return self.raw_bytes == __value.raw_bytes
         return str(self) == str(__value)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Test app:
def perf():
	uuid1 = toUUID(uuid.uuid4())
	uuid2 = toUUID(uuid.uuid4())
	t1 = time.time()
	for i in range(10000000):
		s=uuid1==uuid2
	print(1000*(time.time()-t1))

Original by str spend: 5834.417343139648
Patched : 337.04090118408203