### PR TITLE
feat: increase performance up to 10x on exists string to uuid, 2x for new.

### DIFF
--- a/palworld_save_tools/archive.py
+++ b/palworld_save_tools/archive.py
@@ -80,7 +80,7 @@ class UUID:
         return "%s.UUID('%s')" % (self.__module__, str(self))
 
     def __hash__(self) -> int:
-        return hash(self.raw_bytes)
+        return hash(str(self))
 
 
 # Specify a type for JSON-serializable objects

--- a/palworld_save_tools/archive.py
+++ b/palworld_save_tools/archive.py
@@ -13,13 +13,15 @@ _bytes = bytes
 class UUID:
     """Wrapper around uuid.UUID to delay evaluation of UUIDs until necessary"""
 
-    __slots__ = ("raw_bytes", "parsed_uuid")
+    __slots__ = ("raw_bytes", "parsed_uuid", "parsed_str")
     raw_bytes: bytes
     parsed_uuid: Optional[uuid.UUID]
+    parsed_str: Optional[str]
 
     def __init__(self, raw_bytes: bytes) -> None:
         self.raw_bytes = raw_bytes
         self.parsed_uuid = None
+        self.parsed_str = None
 
     @staticmethod
     def from_str(s: str) -> "UUID":
@@ -48,6 +50,14 @@ class UUID:
         )
 
     def __str__(self) -> str:
+        if not self.parsed_str:
+            b = self.raw_bytes
+            self.parsed_str = "%08x-%04x-%04x-%04x-%04x%08x" % ((b[3] << 24) | (b[2] << 16) | (b[1] << 8) | (b[0]),
+                                 (b[7] << 8) | (b[6]), (b[5] << 8) | (b[4]), (b[0xB] << 8) | (b[0xA]),
+                                 (b[9] << 8) | (b[8]), (b[0xF] << 24) | (b[0xE] << 16) | (b[0xD] << 8) | (b[0xC]))
+        return self.parsed_str
+
+    def UUID(self) -> uuid.UUID:
         if not self.parsed_uuid:
             b = self.raw_bytes
             uuid_int = (
@@ -69,7 +79,7 @@ class UUID:
                 + (b[0x3] << 120)
             )
             self.parsed_uuid = uuid.UUID(int=uuid_int)
-        return str(self.parsed_uuid)
+        return self.parsed_uuid
 
     def __eq__(self, __value: object) -> bool:
         if isinstance(__value, UUID):


### PR DESCRIPTION
def perf_new():
	t1 = time.time()
	for i in range(10000000):
		s=str(UUID(b'\xbc\x99\xfe\xf6{\x0bLO\x8en\xe8\xb4\x1aC;5'))
	print(1000*(time.time()-t1))

def perf_exists():
	t1 = time.time()
	uuids = UUID(b'\xbc\x99\xfe\xf6{\x0bLO\x8en\xe8\xb4\x1aC;5')
	for i in range(10000000):
		s=str(uuids)
	print(1000*(time.time()-t1))

>>> perf_exists()
Old -> 2681.8525791168213
New -> 277.8770923614502

>>> perf_new()
Old -> 11315.203666687012
New -> 6226.833820343018

increase performance up to 10x on exists string to uuid, 2x for new.
reduce some performance for hash, but can be use just string to match in dict, just hash as UUID string