### PR TITLE
Fix no custom properties when set to "all" bug

### DIFF
--- a/palworld_save_tools/commands/convert.py
+++ b/palworld_save_tools/commands/convert.py
@@ -105,7 +105,7 @@ def convert_sav_to_json(
         raw_gvas, _ = decompress_sav_to_gvas(data)
     print(f"Loading GVAS file")
     custom_properties = {}
-    if len(custom_properties) > 0 and custom_properties_keys[0] == "all":
+    if len(custom_properties_keys) > 0 and custom_properties_keys[0] == "all":
         custom_properties = PALWORLD_CUSTOM_PROPERTIES
     else:
         for prop in PALWORLD_CUSTOM_PROPERTIES:


### PR DESCRIPTION
The if statement branch is never taken in this scenario because the length of `custom_properties` will always be zero. Meaning, anyone using this function directly will never be able to use the default "all" value for `custom_properties_keys`.

It seems to be a small typo and the intention was to ensure the `custom_properties_keys` list has at least one element in it before indexing to avoid a potential runtime error.

I've made the small fix here, if you would like to merge it.