### PR TITLE
fix: 0.3.7 compat by temporarily disabling item slot data

### DIFF
--- a/palworld_save_tools/archive.py
+++ b/palworld_save_tools/archive.py
@@ -894,8 +894,9 @@ class FArchiveWriter:
             self.optional_guid(property.get("id", None))
             if property["value"]["type"] == "None":
                 self.byte(property["value"]["value"])
+                size = 1
             else:
-                self.fstring(property["value"]["value"])
+                size = self.fstring(property["value"]["value"])
         elif property_type == "ArrayProperty":
             self.fstring(property["array_type"])
             self.optional_guid(property.get("id", None))

--- a/palworld_save_tools/archive.py
+++ b/palworld_save_tools/archive.py
@@ -402,6 +402,11 @@ class FArchiveReader:
                 "id": self.optional_guid(),
                 "value": self.i32(),
             }
+        elif type_name == "UInt16Property":
+            value = {
+                "id": self.optional_guid(),
+                "value": self.u16(),
+            }
         elif type_name == "UInt32Property":
             value = {
                 "id": self.optional_guid(),
@@ -447,6 +452,20 @@ class FArchiveReader:
             value = {
                 "value": self.bool(),
                 "id": self.optional_guid(),
+            }
+        elif type_name == "ByteProperty":
+            enum_type = self.fstring()
+            _id = self.optional_guid()
+            if enum_type == "None":
+                enum_value = self.byte()
+            else:
+                enum_value = self.fstring()
+            value = {
+                "id": _id,
+                "value": {
+                    "type": enum_type,
+                    "value": enum_value,
+                },
             }
         elif type_name == "ArrayProperty":
             array_type = self.fstring()
@@ -836,6 +855,10 @@ class FArchiveWriter:
             self.optional_guid(property.get("id", None))
             self.i32(property["value"])
             size = 4
+        elif property_type == "UInt16Property":
+            self.optional_guid(property.get("id", None))
+            self.u16(property["value"])
+            size = 2
         elif property_type == "UInt32Property":
             self.optional_guid(property.get("id", None))
             self.u32(property["value"])
@@ -866,6 +889,13 @@ class FArchiveWriter:
             self.bool(property["value"])
             self.optional_guid(property.get("id", None))
             size = 0
+        elif property_type == "ByteProperty":
+            self.fstring(property["value"]["type"])
+            self.optional_guid(property.get("id", None))
+            if property["value"]["type"] == "None":
+                self.byte(property["value"]["value"])
+            else:
+                self.fstring(property["value"]["value"])
         elif property_type == "ArrayProperty":
             self.fstring(property["array_type"])
             self.optional_guid(property.get("id", None))

--- a/palworld_save_tools/paltypes.py
+++ b/palworld_save_tools/paltypes.py
@@ -119,4 +119,7 @@ PALWORLD_CUSTOM_PROPERTIES: dict[
 DISABLED_PROPERTIES = {
     ".worldSaveData.BaseCampSaveData.Value.ModuleMap",
     ".worldSaveData.MapObjectSaveData",
+    # Broken in v0.3.7 - memory optimisation, UObject fields encoded into raw data
+    # Parsing behaviour can be controlled with CustomVersionData
+    ".worldSaveData.ItemContainerSaveData.Value.Slots.Slots.RawData",
 }

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -27,6 +27,7 @@ class TestCliScripts(unittest.TestCase):
             ("v0.3.2/Level-1.sav"),
             ("v0.3.2/Level-2.sav"),
             ("v0.3.2/Level-3.sav"),
+            ("v0.3.7/Level.sav"),
         ]
     )
     def test_sav_roundtrip(self, file_name):


### PR DESCRIPTION
1. Add missing properties
2. Temporarily disable item slot data parsing until I get time to properly look into this