### PR TITLE
handle trailing unparsed data

### DIFF
--- a/palworld_save_tools/rawdata/character_container.py
+++ b/palworld_save_tools/rawdata/character_container.py
@@ -26,7 +26,7 @@ def decode_bytes(
         "permission_tribe_id": reader.byte(),
     }
     if not reader.eof():
-        raise Exception("Warning: EOF not reached")
+        data["trailing_unparsed_data"] = [b for b in reader.read_to_end()]
     return data
 
 
@@ -48,5 +48,7 @@ def encode_bytes(p: dict[str, Any]) -> bytes:
     writer.guid(p["player_uid"])
     writer.guid(p["instance_id"])
     writer.byte(p["permission_tribe_id"])
+    if "trailing_unparsed_data" in p:
+        writer.write(bytes(p["trailing_unparsed_data"]))
     encoded_bytes = writer.bytes()
     return encoded_bytes

--- a/palworld_save_tools/rawdata/foliage_model_instance.py
+++ b/palworld_save_tools/rawdata/foliage_model_instance.py
@@ -37,7 +37,7 @@ def decode_bytes(
     }
     data["hp"] = reader.i32()
     if not reader.eof():
-        raise Exception("Warning: EOF not reached")
+        data["trailing_unparsed_data"] = [b for b in reader.read_to_end()]
     return data
 
 
@@ -69,6 +69,7 @@ def encode_bytes(p: dict[str, Any]) -> bytes:
     )
     writer.float(p["world_transform"]["scale_x"])
     writer.i32(p["hp"])
-
+    if "trailing_unparsed_data" in p:
+        writer.write(bytes(p["trailing_unparsed_data"]))
     encoded_bytes = writer.bytes()
     return encoded_bytes

--- a/palworld_save_tools/rawdata/group.py
+++ b/palworld_save_tools/rawdata/group.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Any, Sequence, Optional
 
 from palworld_save_tools.archive import *
 
@@ -12,70 +12,142 @@ def decode(
     # Decode the raw bytes and replace the raw data
     group_map = value["value"]
     for group in group_map:
-        group_type = group["value"]["GroupType"]["value"]["value"]
-        group_bytes = group["value"]["RawData"]["value"]["values"]
-        group["value"]["RawData"]["value"] = decode_bytes(
-            reader, group_bytes, group_type
-        )
+        try:
+            group_type = group["value"]["GroupType"]["value"]["value"]
+            group_bytes = group["value"]["RawData"]["value"]["values"]
+            group["value"]["RawData"]["value"] = decode_bytes(
+                reader, group_bytes, group_type
+            )
+        except Exception as e:
+            print(f"Error decoding group of type {group.get('value', {}).get('GroupType', {}).get('value', {}).get('value', 'unknown')}: {e}")
+            # Keep the raw bytes if we can't decode
+            if "value" in group and "RawData" in group["value"] and "value" in group["value"]["RawData"]:
+                group["value"]["RawData"]["value"] = {"values": group_bytes, "error": str(e)}
     return value
 
 
 def decode_bytes(
     parent_reader: FArchiveReader, group_bytes: Sequence[int], group_type: str
 ) -> dict[str, Any]:
-    reader = parent_reader.internal_copy(bytes(group_bytes), debug=False)
-    group_data = {
-        "group_type": group_type,
-        "group_id": reader.guid(),
-        "group_name": reader.fstring(),
-        "individual_character_handle_ids": reader.tarray(instance_id_reader),
-    }
-    if group_type in [
-        "EPalGroupType::Guild",
-        "EPalGroupType::IndependentGuild",
-        "EPalGroupType::Organization",
-    ]:
-        org = {
-            "org_type": reader.byte(),
-            "base_ids": reader.tarray(uuid_reader),
+    if len(group_bytes) == 0:
+        return {"values": []}
+
+    try:
+        reader = parent_reader.internal_copy(bytes(group_bytes), debug=False)
+        group_data = {
+            "group_type": group_type,
+            "group_id": reader.guid(),
+            "group_name": reader.fstring(),
+            "individual_character_handle_ids": reader.tarray(instance_id_reader),
         }
-        group_data |= org
-    if group_type in ["EPalGroupType::Guild", "EPalGroupType::IndependentGuild"]:
-        guild: dict[str, Any] = {
-            "base_camp_level": reader.i32(),
-            "map_object_instance_ids_base_camp_points": reader.tarray(uuid_reader),
-            "guild_name": reader.fstring(),
-        }
-        group_data |= guild
-    if group_type == "EPalGroupType::IndependentGuild":
-        indie = {
-            "player_uid": reader.guid(),
-            "guild_name_2": reader.fstring(),
-            "player_info": {
-                "last_online_real_time": reader.i64(),
-                "player_name": reader.fstring(),
-            },
-        }
-        group_data |= indie
-    if group_type == "EPalGroupType::Guild":
-        guild = {
-            "admin_player_uid": reader.guid(),
-            "players": [],
-        }
-        player_count = reader.i32()
-        for _ in range(player_count):
-            player = {
-                "player_uid": reader.guid(),
-                "player_info": {
+
+        # Handle organization-type groups
+        if group_type in [
+            "EPalGroupType::Guild",
+            "EPalGroupType::IndependentGuild",
+            "EPalGroupType::Organization",
+        ]:
+            # Check that we have enough data before reading
+            if reader.data.tell() + 1 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read org_type for {group_type}")
+                group_data["org_type"] = 0  # Default value
+            else:
+                group_data["org_type"] = reader.byte()
+
+            # Check that we have enough data for the tarray header
+            if reader.data.tell() + 4 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read base_ids for {group_type}")
+                group_data["base_ids"] = []  # Empty list
+            else:
+                group_data["base_ids"] = reader.tarray(uuid_reader)
+
+        # Handle guild-specific data
+        if group_type in ["EPalGroupType::Guild", "EPalGroupType::IndependentGuild"]:
+            if reader.data.tell() + 4 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read base_camp_level for {group_type}")
+                group_data["base_camp_level"] = 0  # Default value
+            else:
+                group_data["base_camp_level"] = reader.i32()
+
+            if reader.data.tell() + 4 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read map_object_instance_ids_base_camp_points for {group_type}")
+                group_data["map_object_instance_ids_base_camp_points"] = []  # Empty list
+            else:
+                group_data["map_object_instance_ids_base_camp_points"] = reader.tarray(uuid_reader)
+
+            if reader.data.tell() + 4 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read guild_name for {group_type}")
+                group_data["guild_name"] = ""  # Empty string
+            else:
+                group_data["guild_name"] = reader.fstring()
+
+        # Handle independent guild data
+        if group_type == "EPalGroupType::IndependentGuild":
+            if reader.data.tell() + 16 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read player_uid for {group_type}")
+                group_data["player_uid"] = UUID(bytes(b'\0' * 16))  # Default UUID
+            else:
+                group_data["player_uid"] = reader.guid()
+
+            if reader.data.tell() + 4 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read guild_name_2 for {group_type}")
+                group_data["guild_name_2"] = ""  # Empty string
+            else:
+                group_data["guild_name_2"] = reader.fstring()
+
+            if reader.data.tell() + 12 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read player_info for {group_type}")
+                group_data["player_info"] = {
+                    "last_online_real_time": 0,
+                    "player_name": "",
+                }
+            else:
+                group_data["player_info"] = {
                     "last_online_real_time": reader.i64(),
                     "player_name": reader.fstring(),
-                },
-            }
-            guild["players"].append(player)
-        group_data |= guild
-    if not reader.eof():
-        raise Exception("Warning: EOF not reached")
-    return group_data
+                }
+
+        # Handle guild data
+        if group_type == "EPalGroupType::Guild":
+            if reader.data.tell() + 16 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read admin_player_uid for {group_type}")
+                group_data["admin_player_uid"] = UUID(bytes(b'\0' * 16))  # Default UUID
+            else:
+                group_data["admin_player_uid"] = reader.guid()
+
+            if reader.data.tell() + 4 > len(reader.data.getvalue()):
+                print(f"Warning: Not enough data to read player_count for {group_type}")
+                group_data["players"] = []  # Empty list
+            else:
+                player_count = reader.i32()
+                group_data["players"] = []
+                for _ in range(player_count):
+                    if reader.data.tell() + 16 > len(reader.data.getvalue()):
+                        print(f"Warning: Not enough data to read player_uid in players for {group_type}")
+                        break
+
+                    try:
+                        player = {
+                            "player_uid": reader.guid(),
+                            "player_info": {
+                                "last_online_real_time": reader.i64(),
+                                "player_name": reader.fstring(),
+                            },
+                        }
+                        group_data["players"].append(player)
+                    except Exception as e:
+                        print(f"Error reading player in players for {group_type}: {e}")
+                        break
+
+        # Store any trailing data
+        if not reader.eof():
+            group_data["trailing_unparsed_data"] = [b for b in reader.read_to_end()]
+
+        return group_data
+    except Exception as e:
+        print(f"Error decoding group data of type {group_type}: {e}")
+        # Return what we have with an error flag
+        return {"group_type": group_type, "values": group_bytes, "error": str(e)}
 
 
 def encode(
@@ -95,6 +167,12 @@ def encode(
 
 
 def encode_bytes(p: dict[str, Any]) -> bytes:
+    # If there's an error flag or if it's already in the correct format, return the raw bytes
+    if "error" in p or "values" in p:
+        if isinstance(p.get("values"), list):
+            return bytes(p["values"])
+        return bytes()
+
     writer = FArchiveWriter()
     writer.guid(p["group_id"])
     writer.fstring(p["group_name"])
@@ -122,5 +200,7 @@ def encode_bytes(p: dict[str, Any]) -> bytes:
             writer.guid(p["players"][i]["player_uid"])
             writer.i64(p["players"][i]["player_info"]["last_online_real_time"])
             writer.fstring(p["players"][i]["player_info"]["player_name"])
+    if "trailing_unparsed_data" in p:
+        writer.write(bytes(p["trailing_unparsed_data"]))
     encoded_bytes = writer.bytes()
     return encoded_bytes

--- a/palworld_save_tools/rawdata/map_concrete_model.py
+++ b/palworld_save_tools/rawdata/map_concrete_model.py
@@ -451,9 +451,10 @@ def decode_bytes(
         return {"values": m_bytes}
 
     if not reader.eof():
-        raise Exception(
+        print(
             f"Warning: EOF not reached for {object_id} {map_object_concrete_model}: ori: {''.join(f'{b:02x}' for b in m_bytes)} remaining: {reader.size - reader.data.tell()}"
         )
+        data["trailing_unparsed_data"] = [b for b in reader.read_to_end()]
     return data
 
 
@@ -538,5 +539,7 @@ def encode_bytes(p: Optional[dict[str, Any]]) -> bytes:
             f"Unknown map object concrete model {map_object_concrete_model}"
         )
 
+    if "trailing_unparsed_data" in p:
+        writer.write(bytes(p["trailing_unparsed_data"]))
     encoded_bytes = writer.bytes()
     return encoded_bytes

--- a/palworld_save_tools/rawdata/map_model.py
+++ b/palworld_save_tools/rawdata/map_model.py
@@ -39,7 +39,7 @@ def decode_bytes(
     }
     data["created_at"] = reader.i64()
     if not reader.eof():
-        raise Exception("Warning: EOF not reached")
+        data["trailing_unparsed_data"] = [b for b in reader.read_to_end()]
     return data
 
 
@@ -78,6 +78,7 @@ def encode_bytes(p: dict[str, Any]) -> bytes:
     writer.u32(1 if p["stage_instance_id_belong_to"]["valid"] else 0)
 
     writer.i64(p["created_at"])
-
+    if "trailing_unparsed_data" in p:
+        writer.write(bytes(p["trailing_unparsed_data"]))
     encoded_bytes = writer.bytes()
     return encoded_bytes

--- a/palworld_save_tools/rawdata/work.py
+++ b/palworld_save_tools/rawdata/work.py
@@ -248,7 +248,11 @@ def encode_bytes(p: dict[str, Any], work_type: str) -> bytes:
         print(
             f"Unknown EPalWorkTransformType, please report this: {transform_type}: {work_type}"
         )
-        writer.write(p["transform"]["raw_data"])
+        # Convert list to bytes if necessary
+        if isinstance(p["transform"]["raw_data"], list):
+            writer.write(bytes(p["transform"]["raw_data"]))
+        else:
+            writer.write(p["transform"]["raw_data"])
 
     encoded_bytes = writer.bytes()
     return encoded_bytes


### PR DESCRIPTION
Addresses #208. Workaround that allows the tool to still be used with the updated palworld save files by passing the unparsed data to the json when decoding and back when encoding. This data should still be parsed down the line so it is useful to the user. However this fix will prevent the tool from crashing if the tool has not been updated to support the new changes. 