### PR TITLE
docs: add Related Resources section (Palworld Guides companion guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ pip install palworld-save-tools
 - [PalEdit](https://github.com/EternalWraith/PalEdit) - GUI for editing Pals
 - [palworld-server-tool](https://github.com/zaigie/palworld-server-tool) - Managing dedicated servers via RCON and SAV file parsing
 - [palworld-server-toolkit](https://github.com/magicbear/palworld-server-toolkit) - Assorted set of SAV file manipulations
+
+## Related Resources
+
+- [Palworld Guides](https://palworldguides.xyz/) — Palworld tier lists, base builds, Pal breeding chains, and boss strategies.


### PR DESCRIPTION
Thanks for building palworld-save-tools — the .sav↔JSON converter is genuinely useful.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [Palworld Guides](https://palworldguides.xyz/) — Palworld tier lists, base builds, Pal breeding chains, and boss strategies.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `append_end`.)_